### PR TITLE
Refactor ApiResource models to use lazy vals for category & id

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "me.sargunvohra.lib"
-version = "2.3.1"
+version = "2.4.0-SNAPSHOT"
 
 repositories {
     jcenter()

--- a/src/main/kotlin/me/sargunvohra/lib/pokekotlin/model/resource.kt
+++ b/src/main/kotlin/me/sargunvohra/lib/pokekotlin/model/resource.kt
@@ -1,20 +1,40 @@
 package me.sargunvohra.lib.pokekotlin.model
 
+private fun urlToId(url: String): Int {
+    return "/-?[0-9]+/$".toRegex().find(url)!!.value.filter { it.isDigit() || it == '-' }.toInt()
+}
+
+private fun urlToCat(url: String): String {
+    return "/[a-z\\-]+/-?[0-9]+/$".toRegex().find(url)!!.value.filter { it.isLetter() || it == '-' }
+}
+
+private fun resourceUrl(id: Int, category: String): String {
+    return "/api/v2/$category/$id/"
+}
+
 interface ResourceSummary {
     val id: Int
     val category: String
 }
 
 data class ApiResource(
-    override val category: String,
-    override val id: Int
-) : ResourceSummary
+    val url: String
+) : ResourceSummary {
+    constructor(category: String, id: Int) : this(resourceUrl(id, category))
+
+    override val category by lazy { urlToCat(url) }
+    override val id by lazy { urlToId(url) }
+}
 
 data class NamedApiResource(
     val name: String,
-    override val category: String,
-    override val id: Int
-) : ResourceSummary
+    val url: String
+) : ResourceSummary {
+    constructor(name: String, category: String, id: Int) : this(name, resourceUrl(id, category))
+
+    override val category by lazy { urlToCat(url) }
+    override val id by lazy { urlToId(url) }
+}
 
 interface ResourceSummaryList<out T : ResourceSummary> {
     val count: Int

--- a/src/main/kotlin/me/sargunvohra/lib/pokekotlin/util/adapters.kt
+++ b/src/main/kotlin/me/sargunvohra/lib/pokekotlin/util/adapters.kt
@@ -8,14 +8,6 @@ import java.lang.reflect.Type
 import me.sargunvohra.lib.pokekotlin.model.ApiResource
 import me.sargunvohra.lib.pokekotlin.model.NamedApiResource
 
-private fun urlToId(url: String): Int {
-    return "/-?[0-9]+/$".toRegex().find(url)!!.value.filter { it.isDigit() || it == '-' }.toInt()
-}
-
-private fun urlToCat(url: String): String {
-    return "/[a-z\\-]+/-?[0-9]+/$".toRegex().find(url)!!.value.filter { it.isLetter() || it == '-' }
-}
-
 internal class ApiResourceAdapter : JsonDeserializer<ApiResource> {
 
     data class Json(val url: String)
@@ -26,7 +18,7 @@ internal class ApiResourceAdapter : JsonDeserializer<ApiResource> {
         context: JsonDeserializationContext
     ): ApiResource {
         val temp = context.deserialize<Json>(element, TypeToken.get(Json::class.java).type)
-        return ApiResource(category = urlToCat(temp.url), id = urlToId(temp.url))
+        return ApiResource(temp.url)
     }
 }
 
@@ -40,10 +32,6 @@ internal class NamedApiResourceAdapter : JsonDeserializer<NamedApiResource> {
         context: JsonDeserializationContext
     ): NamedApiResource {
         val temp = context.deserialize<Json>(element, TypeToken.get(Json::class.java).type)
-        return NamedApiResource(
-            name = temp.name,
-            category = urlToCat(temp.url),
-            id = urlToId(temp.url)
-        )
+        return NamedApiResource(temp.name, temp.url)
     }
 }


### PR DESCRIPTION
Closes #83 

Moves the regex interpolation of the url to category/id to lazy initialized values in the data classes rather than in the serializer/deserializer. 

This does technically break backwards compatibility as the constructors of `NamedApiResource` and `ApiResource` change, but I thought this shouldn't matter too much as most people would be just using the values already constructed from the api call.

I also tried a bunch of different ways to try and get it to work without the adapters (seeing as they shouldn't be required anymore) but couldn't get anything working due to the way Gson have implemented the reflection.