### PR TITLE
Update Readme(How to Library Download)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ PokeKotlin is available from Bintray. The latest version number is: ![Bintray](h
 ```groovy
 repositories {
     mavenCentral()
-    maven { url 'https://dl.bintray.com/sargunv/maven' }
+    maven { url 'https://jitpack.io' }
 }
 dependencies {
-    implementation 'me.sargunvohra.lib:pokekotlin:<VERSION>'
+    implementation 'com.github.PokeAPI:pokekotlin:<VERSION>'
 }
 ```


### PR DESCRIPTION
The download process described in the readme has been updated to the latest.

https://github.com/PokeAPI/pokekotlin/releases/tag/2.3.1