### PR TITLE
Add java api

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -162,9 +162,7 @@ dokka {
         localDirectory.set(rootDir)
       }
       externalDocumentationLinks { create("ktor") { url("https://api.ktor.io/") } }
-      suppressedFiles.from(
-        "build/generated/ksp/metadata/commonMain/kotlin/co/pokeapi/pokekotlin/_PokeApiImpl.kt"
-      )
+      suppressedFiles.from("build/generated/ksp/")
     }
   }
 }
@@ -199,12 +197,16 @@ tasks.register("generateDocs") {
 
 spotless {
   kotlinGradle {
-    target("*.gradle.kts")
+    target("*.gradle.kts", "demo-app/*.gradle.kts")
     ktfmt().googleStyle()
   }
   kotlin {
-    target("src/**/*.kt")
+    target("src/**/*.kt", "demo-app/src/**/*.kt")
     ktfmt().googleStyle()
+  }
+  java {
+    target("src/**/*.java", "demo-app/src/**/*.java")
+    googleJavaFormat()
   }
   format("markdown") {
     target("*.md", "docs/**/*.md")

--- a/src/commonMain/kotlin/co/pokeapi/pokekotlin/internal/Ktorfit.kt
+++ b/src/commonMain/kotlin/co/pokeapi/pokekotlin/internal/Ktorfit.kt
@@ -1,0 +1,28 @@
+package co.pokeapi.pokekotlin.internal
+
+import de.jensklingenberg.ktorfit.Ktorfit
+import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.plugins.cache.HttpCache
+import io.ktor.client.plugins.cache.storage.CacheStorage
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.ContentType
+import io.ktor.serialization.kotlinx.json.json
+
+internal fun createPokeApiKtorfitBuilder(
+  baseUrl: String,
+  cacheStorage: CacheStorage?,
+  engine: HttpClientEngine,
+  configure: HttpClientConfig<*>.() -> Unit,
+) =
+  Ktorfit.Builder()
+    .baseUrl(baseUrl)
+    .httpClient(
+      HttpClient(engine) {
+        configure()
+        install(HttpCache) { cacheStorage?.let { privateStorage(it) } }
+        install(ContentNegotiation) { json(PokeApiJson, ContentType.Any) }
+        expectSuccess = true
+      }
+    )

--- a/src/jvmMain/kotlin/co/pokeapi/pokekotlin/internal/FutureConverter.kt
+++ b/src/jvmMain/kotlin/co/pokeapi/pokekotlin/internal/FutureConverter.kt
@@ -1,0 +1,37 @@
+package co.pokeapi.pokekotlin.internal
+
+import de.jensklingenberg.ktorfit.Ktorfit
+import de.jensklingenberg.ktorfit.converter.Converter
+import de.jensklingenberg.ktorfit.converter.KtorfitResult
+import de.jensklingenberg.ktorfit.converter.TypeData
+import io.ktor.client.statement.HttpResponse
+import java.util.concurrent.Future
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.future.future
+
+internal class FutureConverter(typeData: TypeData) :
+  Converter.ResponseConverter<HttpResponse, Future<*>> {
+
+  private val resultConverter = ResultConverter(typeData)
+
+  @OptIn(DelicateCoroutinesApi::class)
+  override fun convert(getResponse: suspend () -> HttpResponse): Future<*> {
+    // safe to use GlobalScope as it'll be the Java code's responsibility to handle the future
+    return GlobalScope.future {
+      val result =
+        try {
+          KtorfitResult.Success(getResponse())
+        } catch (throwable: Throwable) {
+          KtorfitResult.Failure(throwable)
+        }
+      resultConverter.convert(result).getOrThrow()
+    }
+  }
+
+  internal object Factory : Converter.Factory {
+    override fun responseConverter(typeData: TypeData, ktorfit: Ktorfit): FutureConverter? {
+      return if (typeData.typeInfo.type != Future::class) null else FutureConverter(typeData)
+    }
+  }
+}

--- a/src/jvmMain/kotlin/co/pokeapi/pokekotlin/java/PokeApi.kt
+++ b/src/jvmMain/kotlin/co/pokeapi/pokekotlin/java/PokeApi.kt
@@ -1,6 +1,6 @@
-package co.pokeapi.pokekotlin
+package co.pokeapi.pokekotlin.java
 
-import co.pokeapi.pokekotlin.internal.ResultConverter
+import co.pokeapi.pokekotlin.internal.FutureConverter
 import co.pokeapi.pokekotlin.internal.createPokeApiKtorfitBuilder
 import co.pokeapi.pokekotlin.internal.getDefaultEngine
 import co.pokeapi.pokekotlin.model.Ability
@@ -60,359 +60,364 @@ import de.jensklingenberg.ktorfit.http.Query
 import io.ktor.client.HttpClientConfig
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.plugins.cache.storage.CacheStorage
-import kotlin.Result
-
-public fun PokeApi(
-  baseUrl: String = "https://pokeapi.co/api/v2/",
-  cacheStorage: CacheStorage? = null,
-  engine: HttpClientEngine = getDefaultEngine(),
-  configure: HttpClientConfig<*>.() -> Unit = {},
-): PokeApi {
-  return createPokeApiKtorfitBuilder(
-      baseUrl = baseUrl,
-      cacheStorage = cacheStorage,
-      engine = engine,
-      configure = configure,
-    )
-    .converterFactories(ResultConverter.Factory)
-    .build()
-    .createPokeApi()
-}
+import java.util.concurrent.Future
 
 public interface PokeApi {
-  public companion object : PokeApi by PokeApi()
+
+  private companion object {
+    @JvmStatic val default: PokeApi by lazy { create() }
+
+    @JvmStatic
+    @JvmOverloads
+    fun create(
+      baseUrl: String = "https://pokeapi.co/api/v2/",
+      cacheStorage: CacheStorage? = null,
+      engine: HttpClientEngine = getDefaultEngine(),
+      configure: HttpClientConfig<*>.() -> Unit = {},
+    ): PokeApi {
+      return createPokeApiKtorfitBuilder(
+          baseUrl = baseUrl,
+          cacheStorage = cacheStorage,
+          engine = engine,
+          configure = configure,
+        )
+        .converterFactories(FutureConverter.Factory)
+        .build()
+        .createPokeApi()
+    }
+  }
 
   // region Resource Lists
 
   // region Berries
 
   @GET("berry/")
-  public suspend fun getBerryList(
+  public fun getBerryListAsync(
     @Query("offset") offset: Int,
     @Query("limit") limit: Int,
-  ): Result<NamedApiResourceList>
+  ): Future<NamedApiResourceList>
 
   @GET("berry-firmness/")
-  public suspend fun getBerryFirmnessList(
+  public fun getBerryFirmnessListAsync(
     @Query("offset") offset: Int,
     @Query("limit") limit: Int,
-  ): Result<NamedApiResourceList>
+  ): Future<NamedApiResourceList>
 
   @GET("berry-flavor/")
-  public suspend fun getBerryFlavorList(
+  public fun getBerryFlavorListAsync(
     @Query("offset") offset: Int,
     @Query("limit") limit: Int,
-  ): Result<NamedApiResourceList>
+  ): Future<NamedApiResourceList>
 
   // endregion Berries
 
   // region Contests
 
   @GET("contest-type/")
-  public suspend fun getContestTypeList(
+  public fun getContestTypeListAsync(
     @Query("offset") offset: Int,
     @Query("limit") limit: Int,
-  ): Result<NamedApiResourceList>
+  ): Future<NamedApiResourceList>
 
   @GET("contest-effect/")
-  public suspend fun getContestEffectList(
+  public fun getContestEffectListAsync(
     @Query("offset") offset: Int,
     @Query("limit") limit: Int,
-  ): Result<ApiResourceList>
+  ): Future<ApiResourceList>
 
   @GET("super-contest-effect/")
-  public suspend fun getSuperContestEffectList(
+  public fun getSuperContestEffectListAsync(
     @Query("offset") offset: Int,
     @Query("limit") limit: Int,
-  ): Result<ApiResourceList>
+  ): Future<ApiResourceList>
 
   // endregion Contests
 
   // region Encounters
 
   @GET("encounter-method/")
-  public suspend fun getEncounterMethodList(
+  public fun getEncounterMethodListAsync(
     @Query("offset") offset: Int,
     @Query("limit") limit: Int,
-  ): Result<NamedApiResourceList>
+  ): Future<NamedApiResourceList>
 
   @GET("encounter-condition/")
-  public suspend fun getEncounterConditionList(
+  public fun getEncounterConditionListAsync(
     @Query("offset") offset: Int,
     @Query("limit") limit: Int,
-  ): Result<NamedApiResourceList>
+  ): Future<NamedApiResourceList>
 
   @GET("encounter-condition-value/")
-  public suspend fun getEncounterConditionValueList(
+  public fun getEncounterConditionValueListAsync(
     @Query("offset") offset: Int,
     @Query("limit") limit: Int,
-  ): Result<NamedApiResourceList>
+  ): Future<NamedApiResourceList>
 
   // endregion
 
   // region Evolution
 
   @GET("evolution-chain/")
-  public suspend fun getEvolutionChainList(
+  public fun getEvolutionChainListAsync(
     @Query("offset") offset: Int,
     @Query("limit") limit: Int,
-  ): Result<ApiResourceList>
+  ): Future<ApiResourceList>
 
   @GET("evolution-trigger/")
-  public suspend fun getEvolutionTriggerList(
+  public fun getEvolutionTriggerListAsync(
     @Query("offset") offset: Int,
     @Query("limit") limit: Int,
-  ): Result<NamedApiResourceList>
+  ): Future<NamedApiResourceList>
 
   // endregion
 
   // region Games
 
   @GET("generation/")
-  public suspend fun getGenerationList(
+  public fun getGenerationListAsync(
     @Query("offset") offset: Int,
     @Query("limit") limit: Int,
-  ): Result<NamedApiResourceList>
+  ): Future<NamedApiResourceList>
 
   @GET("pokedex/")
-  public suspend fun getPokedexList(
+  public fun getPokedexListAsync(
     @Query("offset") offset: Int,
     @Query("limit") limit: Int,
-  ): Result<NamedApiResourceList>
+  ): Future<NamedApiResourceList>
 
   @GET("version/")
-  public suspend fun getVersionList(
+  public fun getVersionListAsync(
     @Query("offset") offset: Int,
     @Query("limit") limit: Int,
-  ): Result<NamedApiResourceList>
+  ): Future<NamedApiResourceList>
 
   @GET("version-group/")
-  public suspend fun getVersionGroupList(
+  public fun getVersionGroupListAsync(
     @Query("offset") offset: Int,
     @Query("limit") limit: Int,
-  ): Result<NamedApiResourceList>
+  ): Future<NamedApiResourceList>
 
   // endregion
 
   // region Items
 
   @GET("item/")
-  public suspend fun getItemList(
+  public fun getItemListAsync(
     @Query("offset") offset: Int,
     @Query("limit") limit: Int,
-  ): Result<NamedApiResourceList>
+  ): Future<NamedApiResourceList>
 
   @GET("item-attribute/")
-  public suspend fun getItemAttributeList(
+  public fun getItemAttributeListAsync(
     @Query("offset") offset: Int,
     @Query("limit") limit: Int,
-  ): Result<NamedApiResourceList>
+  ): Future<NamedApiResourceList>
 
   @GET("item-category/")
-  public suspend fun getItemCategoryList(
+  public fun getItemCategoryListAsync(
     @Query("offset") offset: Int,
     @Query("limit") limit: Int,
-  ): Result<NamedApiResourceList>
+  ): Future<NamedApiResourceList>
 
   @GET("item-fling-effect/")
-  public suspend fun getItemFlingEffectList(
+  public fun getItemFlingEffectListAsync(
     @Query("offset") offset: Int,
     @Query("limit") limit: Int,
-  ): Result<NamedApiResourceList>
+  ): Future<NamedApiResourceList>
 
   @GET("item-pocket/")
-  public suspend fun getItemPocketList(
+  public fun getItemPocketListAsync(
     @Query("offset") offset: Int,
     @Query("limit") limit: Int,
-  ): Result<NamedApiResourceList>
+  ): Future<NamedApiResourceList>
 
   // endregion
 
   // region Moves
 
   @GET("move/")
-  public suspend fun getMoveList(
+  public fun getMoveListAsync(
     @Query("offset") offset: Int,
     @Query("limit") limit: Int,
-  ): Result<NamedApiResourceList>
+  ): Future<NamedApiResourceList>
 
   @GET("move-ailment/")
-  public suspend fun getMoveAilmentList(
+  public fun getMoveAilmentListAsync(
     @Query("offset") offset: Int,
     @Query("limit") limit: Int,
-  ): Result<NamedApiResourceList>
+  ): Future<NamedApiResourceList>
 
   @GET("move-battle-style/")
-  public suspend fun getMoveBattleStyleList(
+  public fun getMoveBattleStyleListAsync(
     @Query("offset") offset: Int,
     @Query("limit") limit: Int,
-  ): Result<NamedApiResourceList>
+  ): Future<NamedApiResourceList>
 
   @GET("move-category/")
-  public suspend fun getMoveCategoryList(
+  public fun getMoveCategoryListAsync(
     @Query("offset") offset: Int,
     @Query("limit") limit: Int,
-  ): Result<NamedApiResourceList>
+  ): Future<NamedApiResourceList>
 
   @GET("move-damage-class/")
-  public suspend fun getMoveDamageClassList(
+  public fun getMoveDamageClassListAsync(
     @Query("offset") offset: Int,
     @Query("limit") limit: Int,
-  ): Result<NamedApiResourceList>
+  ): Future<NamedApiResourceList>
 
   @GET("move-learn-method/")
-  public suspend fun getMoveLearnMethodList(
+  public fun getMoveLearnMethodListAsync(
     @Query("offset") offset: Int,
     @Query("limit") limit: Int,
-  ): Result<NamedApiResourceList>
+  ): Future<NamedApiResourceList>
 
   @GET("move-target/")
-  public suspend fun getMoveTargetList(
+  public fun getMoveTargetListAsync(
     @Query("offset") offset: Int,
     @Query("limit") limit: Int,
-  ): Result<NamedApiResourceList>
+  ): Future<NamedApiResourceList>
 
   // endregion
 
   // region Locations
 
   @GET("location/")
-  public suspend fun getLocationList(
+  public fun getLocationListAsync(
     @Query("offset") offset: Int,
     @Query("limit") limit: Int,
-  ): Result<NamedApiResourceList>
+  ): Future<NamedApiResourceList>
 
   @GET("location-area/")
-  public suspend fun getLocationAreaList(
+  public fun getLocationAreaListAsync(
     @Query("offset") offset: Int,
     @Query("limit") limit: Int,
-  ): Result<NamedApiResourceList>
+  ): Future<NamedApiResourceList>
 
   @GET("pal-park-area/")
-  public suspend fun getPalParkAreaList(
+  public fun getPalParkAreaListAsync(
     @Query("offset") offset: Int,
     @Query("limit") limit: Int,
-  ): Result<NamedApiResourceList>
+  ): Future<NamedApiResourceList>
 
   @GET("region/")
-  public suspend fun getRegionList(
+  public fun getRegionListAsync(
     @Query("offset") offset: Int,
     @Query("limit") limit: Int,
-  ): Result<NamedApiResourceList>
+  ): Future<NamedApiResourceList>
 
   // endregion
 
   // region Machines
 
   @GET("machine/")
-  public suspend fun getMachineList(
+  public fun getMachineListAsync(
     @Query("offset") offset: Int,
     @Query("limit") limit: Int,
-  ): Result<ApiResourceList>
+  ): Future<ApiResourceList>
 
   // endregion
 
   // region Pokemon
 
   @GET("ability/")
-  public suspend fun getAbilityList(
+  public fun getAbilityListAsync(
     @Query("offset") offset: Int,
     @Query("limit") limit: Int,
-  ): Result<NamedApiResourceList>
+  ): Future<NamedApiResourceList>
 
   @GET("characteristic/")
-  public suspend fun getCharacteristicList(
+  public fun getCharacteristicListAsync(
     @Query("offset") offset: Int,
     @Query("limit") limit: Int,
-  ): Result<ApiResourceList>
+  ): Future<ApiResourceList>
 
   @GET("egg-group/")
-  public suspend fun getEggGroupList(
+  public fun getEggGroupListAsync(
     @Query("offset") offset: Int,
     @Query("limit") limit: Int,
-  ): Result<NamedApiResourceList>
+  ): Future<NamedApiResourceList>
 
   @GET("gender/")
-  public suspend fun getGenderList(
+  public fun getGenderListAsync(
     @Query("offset") offset: Int,
     @Query("limit") limit: Int,
-  ): Result<NamedApiResourceList>
+  ): Future<NamedApiResourceList>
 
   @GET("growth-rate/")
-  public suspend fun getGrowthRateList(
+  public fun getGrowthRateListAsync(
     @Query("offset") offset: Int,
     @Query("limit") limit: Int,
-  ): Result<NamedApiResourceList>
+  ): Future<NamedApiResourceList>
 
   @GET("nature/")
-  public suspend fun getNatureList(
+  public fun getNatureListAsync(
     @Query("offset") offset: Int,
     @Query("limit") limit: Int,
-  ): Result<NamedApiResourceList>
+  ): Future<NamedApiResourceList>
 
   @GET("pokeathlon-stat/")
-  public suspend fun getPokeathlonStatList(
+  public fun getPokeathlonStatListAsync(
     @Query("offset") offset: Int,
     @Query("limit") limit: Int,
-  ): Result<NamedApiResourceList>
+  ): Future<NamedApiResourceList>
 
   @GET("pokemon/")
-  public suspend fun getPokemonList(
+  public fun getPokemonListAsync(
     @Query("offset") offset: Int,
     @Query("limit") limit: Int,
-  ): Result<NamedApiResourceList>
+  ): Future<NamedApiResourceList>
 
   @GET("pokemon-color/")
-  public suspend fun getPokemonColorList(
+  public fun getPokemonColorListAsync(
     @Query("offset") offset: Int,
     @Query("limit") limit: Int,
-  ): Result<NamedApiResourceList>
+  ): Future<NamedApiResourceList>
 
   @GET("pokemon-form/")
-  public suspend fun getPokemonFormList(
+  public fun getPokemonFormListAsync(
     @Query("offset") offset: Int,
     @Query("limit") limit: Int,
-  ): Result<NamedApiResourceList>
+  ): Future<NamedApiResourceList>
 
   @GET("pokemon-habitat/")
-  public suspend fun getPokemonHabitatList(
+  public fun getPokemonHabitatListAsync(
     @Query("offset") offset: Int,
     @Query("limit") limit: Int,
-  ): Result<NamedApiResourceList>
+  ): Future<NamedApiResourceList>
 
   @GET("pokemon-shape/")
-  public suspend fun getPokemonShapeList(
+  public fun getPokemonShapeListAsync(
     @Query("offset") offset: Int,
     @Query("limit") limit: Int,
-  ): Result<NamedApiResourceList>
+  ): Future<NamedApiResourceList>
 
   @GET("pokemon-species/")
-  public suspend fun getPokemonSpeciesList(
+  public fun getPokemonSpeciesListAsync(
     @Query("offset") offset: Int,
     @Query("limit") limit: Int,
-  ): Result<NamedApiResourceList>
+  ): Future<NamedApiResourceList>
 
   @GET("stat/")
-  public suspend fun getStatList(
+  public fun getStatListAsync(
     @Query("offset") offset: Int,
     @Query("limit") limit: Int,
-  ): Result<NamedApiResourceList>
+  ): Future<NamedApiResourceList>
 
   @GET("type/")
-  public suspend fun getTypeList(
+  public fun getTypeListAsync(
     @Query("offset") offset: Int,
     @Query("limit") limit: Int,
-  ): Result<NamedApiResourceList>
+  ): Future<NamedApiResourceList>
 
   // endregion
 
   // region Utility
 
   @GET("language/")
-  public suspend fun getLanguageList(
+  public fun getLanguageListAsync(
     @Query("offset") offset: Int,
     @Query("limit") limit: Int,
-  ): Result<NamedApiResourceList>
+  ): Future<NamedApiResourceList>
 
   // endregion
 
@@ -420,179 +425,172 @@ public interface PokeApi {
 
   // region Berries
 
-  @GET("berry/{id}/") public suspend fun getBerry(@Path("id") id: Int): Result<Berry>
+  @GET("berry/{id}/") public fun getBerryAsync(@Path("id") id: Int): Future<Berry>
 
   @GET("berry-firmness/{id}/")
-  public suspend fun getBerryFirmness(@Path("id") id: Int): Result<BerryFirmness>
+  public fun getBerryFirmnessAsync(@Path("id") id: Int): Future<BerryFirmness>
 
   @GET("berry-flavor/{id}/")
-  public suspend fun getBerryFlavor(@Path("id") id: Int): Result<BerryFlavor>
+  public fun getBerryFlavorAsync(@Path("id") id: Int): Future<BerryFlavor>
 
   // endregion Berries
 
   // region Contests
 
   @GET("contest-type/{id}/")
-  public suspend fun getContestType(@Path("id") id: Int): Result<ContestType>
+  public fun getContestTypeAsync(@Path("id") id: Int): Future<ContestType>
 
   @GET("contest-effect/{id}/")
-  public suspend fun getContestEffect(@Path("id") id: Int): Result<ContestEffect>
+  public fun getContestEffectAsync(@Path("id") id: Int): Future<ContestEffect>
 
   @GET("super-contest-effect/{id}/")
-  public suspend fun getSuperContestEffect(@Path("id") id: Int): Result<SuperContestEffect>
+  public fun getSuperContestEffectAsync(@Path("id") id: Int): Future<SuperContestEffect>
 
   // endregion Contests
 
   // region Encounters
 
   @GET("encounter-method/{id}/")
-  public suspend fun getEncounterMethod(@Path("id") id: Int): Result<EncounterMethod>
+  public fun getEncounterMethodAsync(@Path("id") id: Int): Future<EncounterMethod>
 
   @GET("encounter-condition/{id}/")
-  public suspend fun getEncounterCondition(@Path("id") id: Int): Result<EncounterCondition>
+  public fun getEncounterConditionAsync(@Path("id") id: Int): Future<EncounterCondition>
 
   @GET("encounter-condition-value/{id}/")
-  public suspend fun getEncounterConditionValue(
-    @Path("id") id: Int
-  ): Result<EncounterConditionValue>
+  public fun getEncounterConditionValueAsync(@Path("id") id: Int): Future<EncounterConditionValue>
 
   // endregion Contests
 
   // region Evolution
 
   @GET("evolution-chain/{id}/")
-  public suspend fun getEvolutionChain(@Path("id") id: Int): Result<EvolutionChain>
+  public fun getEvolutionChainAsync(@Path("id") id: Int): Future<EvolutionChain>
 
   @GET("evolution-trigger/{id}/")
-  public suspend fun getEvolutionTrigger(@Path("id") id: Int): Result<EvolutionTrigger>
+  public fun getEvolutionTriggerAsync(@Path("id") id: Int): Future<EvolutionTrigger>
 
   // endregion Evolution
 
   // region Games
 
-  @GET("generation/{id}/") public suspend fun getGeneration(@Path("id") id: Int): Result<Generation>
+  @GET("generation/{id}/") public fun getGenerationAsync(@Path("id") id: Int): Future<Generation>
 
-  @GET("pokedex/{id}/") public suspend fun getPokedex(@Path("id") id: Int): Result<Pokedex>
+  @GET("pokedex/{id}/") public fun getPokedexAsync(@Path("id") id: Int): Future<Pokedex>
 
-  @GET("version/{id}/") public suspend fun getVersion(@Path("id") id: Int): Result<Version>
+  @GET("version/{id}/") public fun getVersionAsync(@Path("id") id: Int): Future<Version>
 
   @GET("version-group/{id}/")
-  public suspend fun getVersionGroup(@Path("id") id: Int): Result<VersionGroup>
+  public fun getVersionGroupAsync(@Path("id") id: Int): Future<VersionGroup>
 
   // endregion Games
 
   // region Items
 
-  @GET("item/{id}/") public suspend fun getItem(@Path("id") id: Int): Result<Item>
+  @GET("item/{id}/") public fun getItemAsync(@Path("id") id: Int): Future<Item>
 
   @GET("item-attribute/{id}/")
-  public suspend fun getItemAttribute(@Path("id") id: Int): Result<ItemAttribute>
+  public fun getItemAttributeAsync(@Path("id") id: Int): Future<ItemAttribute>
 
   @GET("item-category/{id}/")
-  public suspend fun getItemCategory(@Path("id") id: Int): Result<ItemCategory>
+  public fun getItemCategoryAsync(@Path("id") id: Int): Future<ItemCategory>
 
   @GET("item-fling-effect/{id}/")
-  public suspend fun getItemFlingEffect(@Path("id") id: Int): Result<ItemFlingEffect>
+  public fun getItemFlingEffectAsync(@Path("id") id: Int): Future<ItemFlingEffect>
 
-  @GET("item-pocket/{id}/")
-  public suspend fun getItemPocket(@Path("id") id: Int): Result<ItemPocket>
+  @GET("item-pocket/{id}/") public fun getItemPocketAsync(@Path("id") id: Int): Future<ItemPocket>
 
   // endregion Items
 
   // region Moves
 
-  @GET("move/{id}/") public suspend fun getMove(@Path("id") id: Int): Result<Move>
+  @GET("move/{id}/") public fun getMoveAsync(@Path("id") id: Int): Future<Move>
 
   @GET("move-ailment/{id}/")
-  public suspend fun getMoveAilment(@Path("id") id: Int): Result<MoveAilment>
+  public fun getMoveAilmentAsync(@Path("id") id: Int): Future<MoveAilment>
 
   @GET("move-battle-style/{id}/")
-  public suspend fun getMoveBattleStyle(@Path("id") id: Int): Result<MoveBattleStyle>
+  public fun getMoveBattleStyleAsync(@Path("id") id: Int): Future<MoveBattleStyle>
 
   @GET("move-category/{id}/")
-  public suspend fun getMoveCategory(@Path("id") id: Int): Result<MoveCategory>
+  public fun getMoveCategoryAsync(@Path("id") id: Int): Future<MoveCategory>
 
   @GET("move-damage-class/{id}/")
-  public suspend fun getMoveDamageClass(@Path("id") id: Int): Result<MoveDamageClass>
+  public fun getMoveDamageClassAsync(@Path("id") id: Int): Future<MoveDamageClass>
 
   @GET("move-learn-method/{id}/")
-  public suspend fun getMoveLearnMethod(@Path("id") id: Int): Result<MoveLearnMethod>
+  public fun getMoveLearnMethodAsync(@Path("id") id: Int): Future<MoveLearnMethod>
 
-  @GET("move-target/{id}/")
-  public suspend fun getMoveTarget(@Path("id") id: Int): Result<MoveTarget>
+  @GET("move-target/{id}/") public fun getMoveTargetAsync(@Path("id") id: Int): Future<MoveTarget>
 
   // endregion Moves
 
   // region Locations
 
-  @GET("location/{id}/") public suspend fun getLocation(@Path("id") id: Int): Result<Location>
+  @GET("location/{id}/") public fun getLocationAsync(@Path("id") id: Int): Future<Location>
 
   @GET("location-area/{id}/")
-  public suspend fun getLocationArea(@Path("id") id: Int): Result<LocationArea>
+  public fun getLocationAreaAsync(@Path("id") id: Int): Future<LocationArea>
 
   @GET("pal-park-area/{id}/")
-  public suspend fun getPalParkArea(@Path("id") id: Int): Result<PalParkArea>
+  public fun getPalParkAreaAsync(@Path("id") id: Int): Future<PalParkArea>
 
-  @GET("region/{id}/") public suspend fun getRegion(@Path("id") id: Int): Result<Region>
+  @GET("region/{id}/") public fun getRegionAsync(@Path("id") id: Int): Future<Region>
 
   // endregion Locations
 
   // region Machines
 
-  @GET("machine/{id}/") public suspend fun getMachine(@Path("id") id: Int): Result<Machine>
+  @GET("machine/{id}/") public fun getMachineAsync(@Path("id") id: Int): Future<Machine>
 
   // endregion
 
   // region Pokemon
 
-  @GET("ability/{id}/") public suspend fun getAbility(@Path("id") id: Int): Result<Ability>
+  @GET("ability/{id}/") public fun getAbilityAsync(@Path("id") id: Int): Future<Ability>
 
   @GET("characteristic/{id}/")
-  public suspend fun getCharacteristic(@Path("id") id: Int): Result<Characteristic>
+  public fun getCharacteristicAsync(@Path("id") id: Int): Future<Characteristic>
 
-  @GET("egg-group/{id}/") public suspend fun getEggGroup(@Path("id") id: Int): Result<EggGroup>
+  @GET("egg-group/{id}/") public fun getEggGroupAsync(@Path("id") id: Int): Future<EggGroup>
 
-  @GET("gender/{id}/") public suspend fun getGender(@Path("id") id: Int): Result<Gender>
+  @GET("gender/{id}/") public fun getGenderAsync(@Path("id") id: Int): Future<Gender>
 
-  @GET("growth-rate/{id}/")
-  public suspend fun getGrowthRate(@Path("id") id: Int): Result<GrowthRate>
+  @GET("growth-rate/{id}/") public fun getGrowthRateAsync(@Path("id") id: Int): Future<GrowthRate>
 
-  @GET("nature/{id}/") public suspend fun getNature(@Path("id") id: Int): Result<Nature>
+  @GET("nature/{id}/") public fun getNatureAsync(@Path("id") id: Int): Future<Nature>
 
   @GET("pokeathlon-stat/{id}/")
-  public suspend fun getPokeathlonStat(@Path("id") id: Int): Result<PokeathlonStat>
+  public fun getPokeathlonStatAsync(@Path("id") id: Int): Future<PokeathlonStat>
 
-  @GET("pokemon/{id}/") public suspend fun getPokemon(@Path("id") id: Int): Result<Pokemon>
+  @GET("pokemon/{id}/") public fun getPokemonAsync(@Path("id") id: Int): Future<Pokemon>
 
   @GET("pokemon/{id}/encounters/")
-  public suspend fun getPokemonEncounterList(
-    @Path("id") id: Int
-  ): Result<List<LocationAreaEncounter>>
+  public fun getPokemonEncounterListAsync(@Path("id") id: Int): Future<List<LocationAreaEncounter>>
 
   @GET("pokemon-color/{id}/")
-  public suspend fun getPokemonColor(@Path("id") id: Int): Result<PokemonColor>
+  public fun getPokemonColorAsync(@Path("id") id: Int): Future<PokemonColor>
 
   @GET("pokemon-form/{id}/")
-  public suspend fun getPokemonForm(@Path("id") id: Int): Result<PokemonForm>
+  public fun getPokemonFormAsync(@Path("id") id: Int): Future<PokemonForm>
 
   @GET("pokemon-habitat/{id}/")
-  public suspend fun getPokemonHabitat(@Path("id") id: Int): Result<PokemonHabitat>
+  public fun getPokemonHabitatAsync(@Path("id") id: Int): Future<PokemonHabitat>
 
   @GET("pokemon-shape/{id}/")
-  public suspend fun getPokemonShape(@Path("id") id: Int): Result<PokemonShape>
+  public fun getPokemonShapeAsync(@Path("id") id: Int): Future<PokemonShape>
 
   @GET("pokemon-species/{id}/")
-  public suspend fun getPokemonSpecies(@Path("id") id: Int): Result<PokemonSpecies>
+  public fun getPokemonSpeciesAsync(@Path("id") id: Int): Future<PokemonSpecies>
 
-  @GET("stat/{id}/") public suspend fun getStat(@Path("id") id: Int): Result<Stat>
+  @GET("stat/{id}/") public fun getStatAsync(@Path("id") id: Int): Future<Stat>
 
-  @GET("type/{id}/") public suspend fun getType(@Path("id") id: Int): Result<Type>
+  @GET("type/{id}/") public fun getTypeAsync(@Path("id") id: Int): Future<Type>
 
   // endregion Pokemon
 
   // region Utility
 
-  @GET("language/{id}/") public suspend fun getLanguage(@Path("id") id: Int): Result<Language>
+  @GET("language/{id}/") public fun getLanguageAsync(@Path("id") id: Int): Future<Language>
 
   // endregion Utility
 }

--- a/src/jvmTest/java/co/pokeapi/pokekotlin/test/LiveJavaTest.java
+++ b/src/jvmTest/java/co/pokeapi/pokekotlin/test/LiveJavaTest.java
@@ -1,0 +1,36 @@
+package co.pokeapi.pokekotlin.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import co.pokeapi.pokekotlin.java.PokeApi;
+import io.ktor.client.plugins.ClientRequestException;
+import io.ktor.http.HttpStatusCode;
+import java.util.concurrent.ExecutionException;
+import org.junit.Test;
+
+public class LiveJavaTest {
+
+  @Test
+  public void resource() throws ExecutionException, InterruptedException {
+    assertEquals("sitrus", PokeApi.getDefault().getBerryAsync(10).get().getName());
+  }
+
+  @Test
+  public void list() throws ExecutionException, InterruptedException {
+    assertEquals(
+        PokeApi.getDefault().getMoveListAsync(0, 50).get().getResults().get(25),
+        PokeApi.getDefault().getMoveListAsync(25, 50).get().getResults().get(0));
+  }
+
+  @Test
+  public void notFound() {
+    var exception =
+        assertThrows(ExecutionException.class, () -> PokeApi.getDefault().getMoveAsync(-1).get());
+
+    assertEquals(ClientRequestException.class, exception.getCause().getClass());
+
+    var cause = (ClientRequestException) exception.getCause();
+    assertEquals(HttpStatusCode.Companion.getNotFound(), cause.getResponse().getStatus());
+  }
+}


### PR DESCRIPTION
Java can't easily use our `suspend fun` API, so this solves #133 by creating a new API based on `Future` for use in Java.

IntelliJ complains about the Java test file, but it otherwise compiles and runs fine 🤷

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
