### PR TITLE
cap the number of resources checked by the bulk test

### DIFF
--- a/src/commonTest/kotlin/co/pokeapi/pokekotlin/test/Ignore.kt
+++ b/src/commonTest/kotlin/co/pokeapi/pokekotlin/test/Ignore.kt
@@ -1,6 +1,0 @@
-package co.pokeapi.pokekotlin.test
-
-/** Stub annotation to act as a typealias destination for non-applied Ignores. */
-@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION) annotation class NoOpIgnore()
-
-@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION) expect annotation class IgnoreOnJvm()

--- a/src/jsTest/kotlin/co/pokeapi/pokekotlin/test/Ignore.js.kt
+++ b/src/jsTest/kotlin/co/pokeapi/pokekotlin/test/Ignore.js.kt
@@ -1,3 +1,0 @@
-package co.pokeapi.pokekotlin.test
-
-actual typealias IgnoreOnJvm = NoOpIgnore

--- a/src/jvmTest/kotlin/co/pokeapi/pokekotlin/test/Ignore.jvm.kt
+++ b/src/jvmTest/kotlin/co/pokeapi/pokekotlin/test/Ignore.jvm.kt
@@ -1,3 +1,0 @@
-package co.pokeapi.pokekotlin.test
-
-actual typealias IgnoreOnJvm = org.junit.Ignore

--- a/src/nativeTest/kotlin/co/pokeapi/pokekotlin/test/Ignore.native.kt
+++ b/src/nativeTest/kotlin/co/pokeapi/pokekotlin/test/Ignore.native.kt
@@ -1,3 +1,0 @@
-package co.pokeapi.pokekotlin.test
-
-actual typealias IgnoreOnJvm = NoOpIgnore

--- a/src/wasmJsTest/kotlin/co/pokeapi/pokekotlin/test/Ignore.wasmJs.kt
+++ b/src/wasmJsTest/kotlin/co/pokeapi/pokekotlin/test/Ignore.wasmJs.kt
@@ -1,3 +1,0 @@
-package co.pokeapi.pokekotlin.test
-
-actual typealias IgnoreOnJvm = NoOpIgnore


### PR DESCRIPTION
Should resolve #125

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
